### PR TITLE
Fixed a typo in the example code in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Or just pull the text from three files, e.g.:
 ```python
 import io
 
-with io.open("left.txt", encoding="utf-8", "rt") as f:
+with io.open("left.txt", "rt", encoding="utf-8") as f:
     left = f.read()
 ```
 
@@ -359,3 +359,9 @@ I found very little information on how typesetters knew how long any given colum
 
 - The algorithm really struggles with different font sizes. I'm not sure how to handle this, other than requiring all columns to be the same font size. If you have a suggestion, please [email me](subalterngames@gmail.com).
 - The regex used is probably sub-optimal. Style markers _must_ be at the start and end of a word. Talmudifier is `ok with _this._` But `_not this_.`
+
+## 10. Changelog
+
+### v1.1.0
+
+- Fixed an error in the example code in this README.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version=1.0,
+    version="1.1.0",
 
     description='Generate Talmud-esque PDFs.',
     long_description="Given three blocks of text (corresponding to three columns), generate a Talmud page.",


### PR DESCRIPTION
Closes #2 

I think this is the only instance in which the args are in the wrong place but maybe there are others?